### PR TITLE
Switch to 'canvas-prebuilt' package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ $ npm install identicon
 
 ## Installing dependencies
 
+If your project already uses `'canvas'` it will use that. Otherwise, it will use `canvas-prebuilt`.
+
 For more information, check the **node-canvas** [Wiki](https://github.com/Automattic/node-canvas/wiki).
 
 ```bash

--- a/identicon.js
+++ b/identicon.js
@@ -28,7 +28,11 @@
  */
 
 var crypto = require('crypto');
-var Canvas = require('canvas') || require('./lib/canvas');
+try {
+  var Canvas = require('canvas');
+} catch (err) {
+  var Canvas = require('canvas-prebuilt') || require('./lib/canvas');
+}
 
 var patch0 = new Array(0, 4, 24, 20);
 var patch1 = new Array(0, 4, 20);

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "licenses": "MIT",
   "engines": {
     "node": ">= 0.10.0"
+  },
+  "dependencies": {
+    "canvas-prebuilt": "^1.6.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 var crypto = require('crypto');
 
-var Image = require('canvas').Image;
+var Image = require('canvas-prebuilt').Image;
 var identicon = require('../identicon');
 
 describe('generate', function() {


### PR DESCRIPTION
Hi, Windows user here. Installing `canvas` is a PITA because of the compile step. This PR replaces the `canvas` dependency with `canvas-prebuilt` to enable a more pleasant install experience.

This is part of my effort to bring identicons to https://github.com/jus/jus/issues/62