### PR TITLE
Configure the dimensions of the canvas correctly

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -2,8 +2,8 @@
 
 var Canvas = module.exports = function Canvas (w, h) {
   var canvas = document.createElement('canvas');
-  this.width = w;
-  this.height = h;
+  canvas.width = w;
+  canvas.height = h;
   return canvas;
 }
 


### PR DESCRIPTION
This fixes an issue when using identicon in a browser environment (i.e. when using the lib/canvas.js module).